### PR TITLE
Initial elastic rules toml push

### DIFF
--- a/rules/cross-platform/credential_access_forced_authentication_pipes.toml
+++ b/rules/cross-platform/credential_access_forced_authentication_pipes.toml
@@ -52,6 +52,7 @@ tags = [
     "Use Case: Active Directory Monitoring",
     "Data Source: System",
     "Resources: Investigation Guide",
+    "vigilant.disabled"
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/network/discovery_potential_port_scan_detected.toml
+++ b/rules/network/discovery_potential_port_scan_detected.toml
@@ -30,7 +30,8 @@ tags = [
     "Use Case: Network Security Monitoring",
     "Data Source: Elastic Defend",
     "Data Source: PAN-OS",
-    "Resources: Investigation Guide"
+    "Resources: Investigation Guide",
+    "vigilant.disabled"
 ]
 timestamp_override = "event.ingested"
 type = "threshold"

--- a/rules/network/discovery_potential_port_scan_detected.toml
+++ b/rules/network/discovery_potential_port_scan_detected.toml
@@ -30,14 +30,13 @@ tags = [
     "Use Case: Network Security Monitoring",
     "Data Source: Elastic Defend",
     "Data Source: PAN-OS",
-    "Resources: Investigation Guide",
-    "vigilant.disabled"
+    "Resources: Investigation Guide"
 ]
 timestamp_override = "event.ingested"
 type = "threshold"
 
 query = '''
-destination.port : * and event.action : "network_flow" and source.ip : (10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16)
+destination.port : * and event.action : "network" and source.ip : (10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16)
 '''
 note = """## Triage and analysis
 

--- a/rules/windows/credential_access_suspicious_lsass_access_via_snapshot.toml
+++ b/rules/windows/credential_access_suspicious_lsass_access_via_snapshot.toml
@@ -37,6 +37,7 @@ tags = [
     "Tactic: Credential Access",
     "Data Source: Sysmon",
     "Resources: Investigation Guide",
+    "vigilant.disabled"
 ]
 timestamp_override = "event.ingested"
 type = "threshold"

--- a/rules/windows/credential_access_via_snapshot_lsass_clone_creation.toml
+++ b/rules/windows/credential_access_via_snapshot_lsass_clone_creation.toml
@@ -42,6 +42,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: System",
     "Resources: Investigation Guide",
+    "vigilant.disabled"
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/windows/defense_evasion_timestomp_sysmon.toml
+++ b/rules/windows/defense_evasion_timestomp_sysmon.toml
@@ -28,6 +28,7 @@ tags = [
     "Tactic: Defense Evasion",
     "Data Source: Sysmon",
     "Resources: Investigation Guide",
+    "vigilant.disabled"
 ]
 timestamp_override = "event.ingested"
 type = "eql"


### PR DESCRIPTION
Disable discovery_potential_port_scan_detected.toml -
disabling because it'll never fire because of `event.action: network_flow`. The alternative action would be to rewrite the logic to be `event.action: network` but I wonder if the rule is good enough to warrant it rather than just the disable

the rest are just disabled because we don't have `event.code` for these indexes but we can't just make `event.code` an incompatible field because it's compatible with other indexes