### PR TITLE
Update persistence_iam_user_created_access_keys_for_another_user.toml

### DIFF
--- a/rules/integrations/aws/persistence_iam_user_created_access_keys_for_another_user.toml
+++ b/rules/integrations/aws/persistence_iam_user_created_access_keys_for_another_user.toml
@@ -112,7 +112,6 @@ from logs-aws.cloudtrail-* metadata _id, _version, _index
     event.outcome,
     user.name,
     source.address,
-    user.target.name,
     user_agent.original,
     aws.cloudtrail.request_parameters,
     aws.cloudtrail.response_elements,

--- a/rules/network/discovery_potential_network_sweep_detected.toml
+++ b/rules/network/discovery_potential_network_sweep_detected.toml
@@ -33,7 +33,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "threshold"
 query = '''
-event.action:network_flow and destination.port:(21 or 22 or 23 or 25 or 139 or 445 or 3389 or 5985 or 5986) and
+event.action:network and destination.port:(21 or 22 or 23 or 25 or 139 or 445 or 3389 or 5985 or 5986) and
 source.ip:(10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16)
 '''
 note = """## Triage and analysis

--- a/rules/network/discovery_potential_syn_port_scan_detected.toml
+++ b/rules/network/discovery_potential_syn_port_scan_detected.toml
@@ -34,7 +34,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "threshold"
 query = '''
-event.action:network_flow and destination.port:* and network.packets <= 2 and source.ip:(10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16)
+event.action:network and destination.port:* and network.packets <= 2 and source.ip:(10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16)
 '''
 note = """## Triage and analysis
 


### PR DESCRIPTION
Fixing rule execution error. Fairly inconsequential change, just removes a field (that doesn't even exist) from the resulting record for context/triagability
```
Rule failure at Feb 6, 2025 @ 15:05:42.101
verification_exception
	Root causes:
		verification_exception: Found 1 problem
line 5:22: Unknown column [user.target.name], did you mean any of [user.name, user.name.text]?
```