### PR TITLE
DS-446 Rules to disable before raising alert cap from 100

### DIFF
--- a/rules/integrations/dga/command_and_control_ml_dns_request_predicted_to_be_a_dga_domain.toml
+++ b/rules/integrations/dga/command_and_control_ml_dns_request_predicted_to_be_a_dga_domain.toml
@@ -53,6 +53,7 @@ tags = [
     "Rule Type: Machine Learning",
     "Tactic: Command and Control",
     "Resources: Investigation Guide",
+    "vigilant.disabled",
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/problemchild/defense_evasion_ml_suspicious_windows_event_high_probability.toml
+++ b/rules/integrations/problemchild/defense_evasion_ml_suspicious_windows_event_high_probability.toml
@@ -55,6 +55,7 @@ tags = [
     "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
     "Resources: Investigation Guide",
+    "vigilant.disabled",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/problemchild/defense_evasion_ml_suspicious_windows_event_low_probability.toml
+++ b/rules/integrations/problemchild/defense_evasion_ml_suspicious_windows_event_low_probability.toml
@@ -53,6 +53,7 @@ tags = [
     "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
     "Resources: Investigation Guide",
+    "vigilant.disabled",
 ]
 timestamp_override = "event.ingested"
 type = "eql"


### PR DESCRIPTION
These are all ML-based (completely blackbox and not up-to-date) rules that are currently firing at crazy rates. Let's turn these off in favor of rules based off the anomaly jobs tracking these model outputs.