### PR TITLE
Disable execution_potential_widespread_malware_infection.toml

### DIFF
--- a/rules/cross-platform/execution_potential_widespread_malware_infection.toml
+++ b/rules/cross-platform/execution_potential_widespread_malware_infection.toml
@@ -27,7 +27,8 @@ tags = [
     "Use Case: Threat Detection",
     "Tactic: Execution",
     "Rule Type: Higher-Order Rule",
-    "Resources: Investigation Guide"
+    "Resources: Investigation Guide",
+    "vigilant.disabled"
 ]
 timestamp_override = "event.ingested"
 type = "esql"


### PR DESCRIPTION
we don't need this higher order rule from elastic