### PR TITLE
Add identity risk tag to all elastic google workspace alerts

### DIFF
--- a/rules/integrations/google_workspace/collection_google_drive_ownership_transferred_via_google_workspace.toml
+++ b/rules/integrations/google_workspace/collection_google_drive_ownership_transferred_via_google_workspace.toml
@@ -89,6 +89,7 @@ tags = [
     "Data Source: Google Workspace",
     "Tactic: Collection",
     "Resources: Investigation Guide",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/google_workspace/collection_google_workspace_custom_gmail_route_created_or_modified.toml
+++ b/rules/integrations/google_workspace/collection_google_workspace_custom_gmail_route_created_or_modified.toml
@@ -89,6 +89,7 @@ tags = [
     "Data Source: Google Workspace",
     "Tactic: Collection",
     "Resources: Investigation Guide",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/google_workspace/credential_access_google_workspace_drive_encryption_key_accessed_by_anonymous_user.toml
+++ b/rules/integrations/google_workspace/credential_access_google_workspace_drive_encryption_key_accessed_by_anonymous_user.toml
@@ -86,6 +86,7 @@ tags = [
     "Use Case: Configuration Audit",
     "Tactic: Credential Access",
     "Resources: Investigation Guide",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/google_workspace/defense_evasion_application_removed_from_blocklist_in_google_workspace.toml
+++ b/rules/integrations/google_workspace/defense_evasion_application_removed_from_blocklist_in_google_workspace.toml
@@ -93,6 +93,7 @@ tags = [
     "Use Case: Configuration Audit",
     "Resources: Investigation Guide",
     "Tactic: Defense Evasion",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/google_workspace/defense_evasion_domain_added_to_google_workspace_trusted_domains.toml
+++ b/rules/integrations/google_workspace/defense_evasion_domain_added_to_google_workspace_trusted_domains.toml
@@ -88,6 +88,7 @@ tags = [
     "Use Case: Configuration Audit",
     "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/google_workspace/defense_evasion_google_workspace_bitlocker_setting_disabled.toml
+++ b/rules/integrations/google_workspace/defense_evasion_google_workspace_bitlocker_setting_disabled.toml
@@ -88,6 +88,7 @@ tags = [
     "Use Case: Configuration Audit",
     "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/google_workspace/defense_evasion_google_workspace_new_oauth_login_from_third_party_application.toml
+++ b/rules/integrations/google_workspace/defense_evasion_google_workspace_new_oauth_login_from_third_party_application.toml
@@ -78,7 +78,7 @@ references = [
 risk_score = 47
 rule_id = "21bafdf0-cf17-11ed-bd57-f661ea17fbcc"
 severity = "medium"
-tags = ["Domain: Cloud", "Data Source: Google Workspace", "Tactic: Defense Evasion", "Tactic: Initial Access", "Resources: Investigation Guide"]
+tags = ["Domain: Cloud", "Data Source: Google Workspace", "Tactic: Defense Evasion", "Tactic: Initial Access", "Resources: Investigation Guide", "vigilant.alerting.identity_risk"]
 timestamp_override = "event.ingested"
 type = "new_terms"
 

--- a/rules/integrations/google_workspace/defense_evasion_restrictions_for_marketplace_modified_to_allow_any_app.toml
+++ b/rules/integrations/google_workspace/defense_evasion_restrictions_for_marketplace_modified_to_allow_any_app.toml
@@ -95,6 +95,7 @@ tags = [
     "Use Case: Configuration Audit",
     "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/google_workspace/google_workspace_alert_center_promotion.toml
+++ b/rules/integrations/google_workspace/google_workspace_alert_center_promotion.toml
@@ -38,7 +38,6 @@ references = [
 ]
 risk_score = 73
 rule_id = "f1a6d0f4-95b8-11ed-9517-f661ea17fbcc"
-rule_name_override = "google_workspace.alert.type"
 severity = "high"
 tags = [
     "Domain: Cloud",
@@ -46,6 +45,7 @@ tags = [
     "Use Case: Log Auditing",
     "Use Case: Threat Detection",
     "Resources: Investigation Guide",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/google_workspace/impact_google_workspace_admin_role_deletion.toml
+++ b/rules/integrations/google_workspace/impact_google_workspace_admin_role_deletion.toml
@@ -88,6 +88,7 @@ tags = [
     "Use Case: Identity and Access Audit",
     "Tactic: Impact",
     "Resources: Investigation Guide",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/google_workspace/impact_google_workspace_mfa_enforcement_disabled.toml
+++ b/rules/integrations/google_workspace/impact_google_workspace_mfa_enforcement_disabled.toml
@@ -90,6 +90,7 @@ tags = [
     "Use Case: Configuration Audit",
     "Tactic: Impact",
     "Resources: Investigation Guide",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/google_workspace/initial_access_external_user_added_to_google_workspace_group.toml
+++ b/rules/integrations/google_workspace/initial_access_external_user_added_to_google_workspace_group.toml
@@ -92,6 +92,7 @@ tags = [
     "Use Case: Identity and Access Audit",
     "Tactic: Initial Access",
     "Resources: Investigation Guide",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/google_workspace/initial_access_google_workspace_suspended_user_renewed.toml
+++ b/rules/integrations/google_workspace/initial_access_google_workspace_suspended_user_renewed.toml
@@ -83,6 +83,7 @@ tags = [
     "Use Case: Identity and Access Audit",
     "Tactic: Initial Access",
     "Resources: Investigation Guide",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/google_workspace/initial_access_object_copied_to_external_drive_with_app_consent.toml
+++ b/rules/integrations/google_workspace/initial_access_object_copied_to_external_drive_with_app_consent.toml
@@ -94,6 +94,7 @@ tags = [
     "Data Source: Google Workspace",
     "Tactic: Initial Access",
     "Resources: Investigation Guide",
+    "vigilant.alerting.identity_risk"
 ]
 type = "eql"
 

--- a/rules/integrations/google_workspace/persistence_application_added_to_google_workspace_domain.toml
+++ b/rules/integrations/google_workspace/persistence_application_added_to_google_workspace_domain.toml
@@ -92,6 +92,7 @@ tags = [
     "Use Case: Configuration Audit",
     "Tactic: Persistence",
     "Resources: Investigation Guide",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/google_workspace/persistence_google_workspace_2sv_policy_disabled.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_2sv_policy_disabled.toml
@@ -92,6 +92,7 @@ tags = [
     "Use Case: Configuration Audit",
     "Tactic: Persistence",
     "Resources: Investigation Guide",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/google_workspace/persistence_google_workspace_admin_role_assigned_to_user.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_admin_role_assigned_to_user.toml
@@ -95,6 +95,7 @@ tags = [
     "Use Case: Identity and Access Audit",
     "Tactic: Persistence",
     "Resources: Investigation Guide",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/google_workspace/persistence_google_workspace_api_access_granted_via_dwd.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_api_access_granted_via_dwd.toml
@@ -89,6 +89,7 @@ tags = [
     "Use Case: Identity and Access Audit",
     "Resources: Investigation Guide",
     "Tactic: Persistence",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/google_workspace/persistence_google_workspace_custom_admin_role_created.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_custom_admin_role_created.toml
@@ -93,6 +93,7 @@ tags = [
     "Use Case: Identity and Access Audit",
     "Resources: Investigation Guide",
     "Tactic: Persistence",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/google_workspace/persistence_google_workspace_password_policy_modified.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_password_policy_modified.toml
@@ -91,6 +91,7 @@ tags = [
     "Use Case: Identity and Access Audit",
     "Tactic: Persistence",
     "Resources: Investigation Guide",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/google_workspace/persistence_google_workspace_role_modified.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_role_modified.toml
@@ -95,6 +95,7 @@ tags = [
     "Use Case: Identity and Access Audit",
     "Resources: Investigation Guide",
     "Tactic: Persistence",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/google_workspace/persistence_google_workspace_user_organizational_unit_changed.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_user_organizational_unit_changed.toml
@@ -94,6 +94,7 @@ tags = [
     "Use Case: Configuration Audit",
     "Tactic: Persistence",
     "Resources: Investigation Guide",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/google_workspace/persistence_mfa_disabled_for_google_workspace_organization.toml
+++ b/rules/integrations/google_workspace/persistence_mfa_disabled_for_google_workspace_organization.toml
@@ -89,6 +89,7 @@ tags = [
     "Use Case: Identity and Access Audit",
     "Tactic: Persistence",
     "Resources: Investigation Guide",
+    "vigilant.alerting.identity_risk"
 ]
 timestamp_override = "event.ingested"
 type = "query"


### PR DESCRIPTION
1. Add identity_risk to all elastic google workspace signals
2. Remove the name override from this rulesets 'passthrough' like signal 