### PR TITLE
update email redirect alert to passthrough

### DIFF
--- a/rules/integrations/o365/collection_microsoft_365_new_inbox_rule.toml
+++ b/rules/integrations/o365/collection_microsoft_365_new_inbox_rule.toml
@@ -71,7 +71,7 @@ references = [
 risk_score = 47
 rule_id = "ec8efb0c-604d-42fa-ac46-ed1cfbc38f78"
 severity = "medium"
-tags = ["Domain: Cloud", "Data Source: Microsoft 365", "Use Case: Configuration Audit", "Tactic: Collection", "Resources: Investigation Guide", "vigilant.alerting.high_risk", "vigilant.alerting.data_exfiltration"]
+tags = ["Domain: Cloud", "Data Source: Microsoft 365", "Use Case: Configuration Audit", "Tactic: Collection", "Resources: Investigation Guide", "vigilant.alerting.passthrough", "vigilant.alerting.data_exfiltration"]
 timestamp_override = "event.ingested"
 type = "query"
 


### PR DESCRIPTION
11 signals in the last 90 days, numerous duplicates that would have reduced alert count to around 5-6. The other "email forwarding/redirect" rule we have is passthrough so this should be too. 