### PR TITLE
Disable rules that do not work

### DIFF
--- a/rules/cross-platform/impact_alert_from_a_process_with_cpu_spike.toml
+++ b/rules/cross-platform/impact_alert_from_a_process_with_cpu_spike.toml
@@ -58,7 +58,8 @@ tags = [
     "Rule Type: Higher-Order Rule",
     "Resources: Investigation Guide",
     "Domain: Endpoint", 
-    "Tactic: Impact"
+    "Tactic: Impact",
+    "vigilant.disabled",
 ]
 timestamp_override = "event.ingested"
 type = "esql"

--- a/rules/cross-platform/impact_alerts_on_host_with_cpu_spike.toml
+++ b/rules/cross-platform/impact_alerts_on_host_with_cpu_spike.toml
@@ -58,7 +58,8 @@ tags = [
     "Rule Type: Higher-Order Rule",
     "Resources: Investigation Guide",
     "Domain: Endpoint",
-    "Tactic: Impact"
+    "Tactic: Impact",
+    "vigilant.disabled",
 ]
 timestamp_override = "event.ingested"
 type = "esql"

--- a/rules/cross-platform/impact_newly_observed_process_with_high_cpu.toml
+++ b/rules/cross-platform/impact_newly_observed_process_with_high_cpu.toml
@@ -59,7 +59,8 @@ tags = [
     "Use Case: Observavility",
     "Resources: Investigation Guide",
     "Domain: Endpoint",
-    "Tactic: Impact"
+    "Tactic: Impact",
+    "vigilant.disabled",
 ]
 timestamp_override = "event.ingested"
 type = "esql"

--- a/rules/cross-platform/multiple_machine_learning_jobs_by_entity.toml
+++ b/rules/cross-platform/multiple_machine_learning_jobs_by_entity.toml
@@ -18,7 +18,7 @@ references = ["https://www.elastic.co/guide/en/security/current/prebuilt-ml-jobs
 risk_score = 73
 rule_id = "da7f7a93-26e1-49ce-b336-963c6dc17c7b"
 severity = "high"
-tags = ["Use Case: Threat Detection", "Rule Type: Higher-Order Rule", "Resources: Investigation Guide", "Rule Type: Machine Learning"]
+tags = ["Use Case: Threat Detection", "Rule Type: Higher-Order Rule", "Resources: Investigation Guide", "Rule Type: Machine Learning", "vigilant.disabled"]
 timestamp_override = "event.ingested"
 type = "esql"
 

--- a/rules/integrations/azure/impact_azure_compute_vm_snapshot_deletions.toml
+++ b/rules/integrations/azure/impact_azure_compute_vm_snapshot_deletions.toml
@@ -81,6 +81,8 @@ tags = [
     "Use Case: Threat Detection",
     "Tactic: Impact",
     "Resources: Investigation Guide",
+    "vigilant.alerting.passthrough",
+    "vigilant.alerting.sensitive_environment_changes",
 ]
 timestamp_override = "event.ingested"
 type = "threshold"

--- a/rules/windows/credential_access_bruteforce_admin_account.toml
+++ b/rules/windows/credential_access_bruteforce_admin_account.toml
@@ -101,6 +101,7 @@ tags = [
     "Tactic: Credential Access",
     "Resources: Investigation Guide",
     "Data Source: Windows Security Event Logs",
+    "vigilant.disabled",
 ]
 type = "esql"
 

--- a/rules/windows/credential_access_bruteforce_multiple_logon_failure_same_srcip.toml
+++ b/rules/windows/credential_access_bruteforce_multiple_logon_failure_same_srcip.toml
@@ -115,6 +115,7 @@ tags = [
     "Tactic: Credential Access",
     "Resources: Investigation Guide",
     "Data Source: Windows Security Event Logs",
+    "vigilant.disabled",
 ]
 timestamp_override = "event.ingested"
 type = "esql"

--- a/rules/windows/privilege_escalation_account_takeover_mixed_logon_types.toml
+++ b/rules/windows/privilege_escalation_account_takeover_mixed_logon_types.toml
@@ -51,6 +51,7 @@ tags = [
     "Tactic: Privilege Escalation",
     "Data Source: Windows Security Event Logs",
     "Resources: Investigation Guide",
+    "vigilant.disabled",
 ]
 timestamp_override = "event.ingested"
 type = "esql"

--- a/rules/windows/privilege_escalation_takeover_new_source_ip.toml
+++ b/rules/windows/privilege_escalation_takeover_new_source_ip.toml
@@ -50,6 +50,7 @@ tags = [
     "Tactic: Privilege Escalation",
     "Data Source: Windows Security Event Logs",
     "Resources: Investigation Guide",
+    "vigilant.disabled",
 ]
 timestamp_override = "event.ingested"
 type = "esql"

--- a/rules_building_block/execution_mcp_server_child_process.toml
+++ b/rules_building_block/execution_mcp_server_child_process.toml
@@ -41,6 +41,7 @@ tags = [
     "Rule Type: BBR",
     "Domain: LLM",
     "Mitre Atlas: T0053",
+    "vigilant.disabled",
 ]
 timestamp_override = "event.ingested"
 type = "eql"


### PR DESCRIPTION
Disabled rules:
- metrics go to ops so these dont work
  - `Newly Observed Process Exhibiting High CPU Usage`
  - `Multiple Alerts on a Host Exhibiting CPU Spike`
  - `Detection Alert on a Process Exhibiting CPU Spike`
- unused integration input
  - `Privileged Account Brute Force`
  - `Potential Account Takeover - Mixed Logon Types`
  - `Multiple Logon Failure from the same Source Address`
  - `Potential Account Takeover - Logon from New Source IP`
- we dont use ML
  - `Multiple Machine Learning Alerts by Influencer Field`
- way too noisy
  - `GenAI or MCP Server Child Process Execution`


Other changes:
- add tags
  - `Azure Compute Snapshot Deletions by User`